### PR TITLE
Feature/proxy problem

### DIFF
--- a/src/main/java/com/advanced/AdvancedApplication.java
+++ b/src/main/java/com/advanced/AdvancedApplication.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Import;
 //@Import(BeanPostProcessorConfig.class)
 //@Import(AutoProxyConfig.class)
 //@Import(AopConfig.class)
-@SpringBootApplication(scanBasePackages = "com.advanced.internalcall")
+@SpringBootApplication(scanBasePackages = "com.advanced.member")
 public class AdvancedApplication {
 
     public static void main(String[] args) {

--- a/src/test/java/com/advanced/proxyvs/ProxyCastingTest.java
+++ b/src/test/java/com/advanced/proxyvs/ProxyCastingTest.java
@@ -1,0 +1,43 @@
+package com.advanced.proxyvs;
+
+import com.advanced.member.MemberService;
+import com.advanced.member.MemberServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JDK 동적 프록시는 대상 객체(인터페이스)의 구현체로 캐스팅할 수 없다!!
+ * CGLIB 는 구체 클래스를 기반으로 프록시를 생성하므로 캐스팅할 수 있다
+ */
+@Slf4j
+public class ProxyCastingTest {
+
+    @Test
+    void jdkProxy() {
+        MemberServiceImpl target = new MemberServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(false); //인터페이스 기반인 JDK 동적 프록시
+
+        MemberService memberServiceProxy = (MemberService) proxyFactory.getProxy(); //MemberService 인터페이스 기반으로 JDK 프록시 생성
+        log.info("proxy class={}", memberServiceProxy.getClass());
+        //JDK 동적 프록시는 인터페이스를 구현하므로 구체 타입으로 캐스팅 불가능
+        assertThrows(ClassCastException.class, () -> {
+            MemberServiceImpl castingMemberService = (MemberServiceImpl) memberServiceProxy;
+        });
+    }
+
+    @Test
+    void cglibProxy() {
+        MemberServiceImpl target = new MemberServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(true); //CGLIB 프록시
+
+        MemberService memberServiceProxy = (MemberService) proxyFactory.getProxy();
+        log.info("proxy class={}", memberServiceProxy.getClass());
+        MemberServiceImpl castingMemberService = (MemberServiceImpl) memberServiceProxy; //CGLIB 프록시를 구현 클래스로 캐스팅
+    }
+}

--- a/src/test/java/com/advanced/proxyvs/code/ProxyDIAspect.java
+++ b/src/test/java/com/advanced/proxyvs/code/ProxyDIAspect.java
@@ -1,0 +1,16 @@
+package com.advanced.proxyvs.code;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Slf4j
+@Aspect
+public class ProxyDIAspect {
+
+    @Before("execution(* com.advanced..*.*(..))")
+    public void doTrace(JoinPoint joinPoint) {
+        log.info("[proxyDIAdvice] {}", joinPoint.getSignature());
+    }
+}

--- a/src/test/java/com/advanced/proxyvs/code/ProxyDiTest.java
+++ b/src/test/java/com/advanced/proxyvs/code/ProxyDiTest.java
@@ -1,0 +1,47 @@
+package com.advanced.proxyvs.code;
+
+import com.advanced.member.MemberService;
+import com.advanced.member.MemberServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+//@SpringBootTest(properties = {"spring.aop.proxy-target-class=false"}) //스프링이 AOP 프록시를 생성할떄 JDK 동적 프록시를 우선 생성하도록 설정(인터페이스가 없다면 GGLIB 사용)
+@SpringBootTest(properties = {"spring.aop.proxy-target-class=true"}) //CGLIB 프록시 생성
+@Import(ProxyDIAspect.class)
+public class ProxyDiTest {
+
+    @Autowired
+    MemberService memberService;
+
+    /**
+     * JDK 동적 프록시는 구현체를 모르기 때문에 의존관계 주입 불가
+     * 그러나 CGLIB 는 구현 클래스를 기반으로 프록시가 생성되기 때문에 타입 캐스팅 가능
+     */
+    @Autowired
+    MemberServiceImpl memberServiceImpl;
+
+    @Test
+    void goJDKProxy() {
+        log.info("memberService class={}", memberService.getClass());
+        log.info("memberServiceImpl class={}", memberServiceImpl.getClass());
+
+        //예상된 주입은 memberServiceImpl 이지만 실제 넘어온 타입은 프록시 이기 때문에 예외 발생
+        Assertions.assertThrows(UnsatisfiedDependencyException.class,
+                () -> memberServiceImpl.hello("hello")
+        );
+    }
+
+    @Test
+    void goCGLIB() {
+        log.info("memberService class={}", memberService.getClass());
+        log.info("memberServiceImpl class={}", memberServiceImpl.getClass());
+
+        memberServiceImpl.hello("hello");
+    }
+}


### PR DESCRIPTION
JDK 동적 프록시 문제점 - 구현 클래스를 주입할 수 없음, CGLIB 단점 - 생성자 2번 호출(현 스프링 버전에서 해결됨) 학습